### PR TITLE
feat: support the Pine64 SOQuartz CM4 module

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -12,5 +12,10 @@ vars:
   uboot_version: 2024.01
   uboot_sha256: b99611f1ed237bf3541bdc8434b68c96a6e05967061f992443cb30aabebef5b3
   uboot_sha512: 45bd093ba3bda23e43cdde83d8656c1ee1348ac2886ecff1fee475f101ac4965a5be6565408fa5b990c723f3fdc833edfca60a719f735a43040cd14a1b59a88b
+
+  # renovate: datasource=git-refs versioning=git depName=https://github.com/rockchip/rkbin
+  rkbin_ref: a2a0b89b6c8c612dca5ed9ed8a68db8a07f68bc0
+  rkbin_sha256: 9df375316869daadbf874410f4097591c32cc2dca5a30fd328ea7a1cd8f8b6a8
+  rkbin_sha512: 715253b5ef5c7fbcbce8478d4dea5ad3d1b4b738da437b5f0e9b31eed20f9bcb86cab082e4c04c69b42b6ffcc2cbb1a31079b33b968bb76826ff0dd4f83043e1
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/sbc-rockchip

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ This repo provides the overlay for RockChip based Talos image.
 | rockpi4              | Rock Pi 4A,Rock Pi 4B | Generic overlay for Rock Pi 4A and Rock Pi 4B |
 | rockpi4c             | Rock Pi 4C            | Overlay for Rock Pi 4C                        |
 | rock4cplus           | Radxa ROCK 4C+        | Overlay for Radxa ROCK 4C+                    |
+| soquartz-cm4         | Pine64 SOQuartz CM4   | Overlay for Pine64 SOQuartz CM4 module        |

--- a/artifacts/rkbin/pkg.yaml
+++ b/artifacts/rkbin/pkg.yaml
@@ -1,0 +1,20 @@
+name: rkbin
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://github.com/rockchip-linux/rkbin/archive/{{ .rkbin_ref }}.tar.gz
+        destination: rkbin.tar.gz
+        sha256: "{{ .rkbin_sha256 }}"
+        sha512: "{{ .rkbin_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    install:
+      - |
+        mkdir -p /rootfs/rkbin
+        tar xf rkbin.tar.gz --strip-components=1 -C /rootfs/rkbin
+finalize:
+  - from: /rootfs
+    to: /libs

--- a/artifacts/soquartz-cm4/pkg.yaml
+++ b/artifacts/soquartz-cm4/pkg.yaml
@@ -1,0 +1,41 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-soquartz-cm4
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: rkbin
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_sha256 }}"
+        sha512: "{{ .uboot_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      # soquartz-cm4-rk3566
+      - |
+        mkdir -p /usr/bin \
+          && ln -sf /toolchain/bin/env /usr/bin/env \
+          && ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install pyelftools
+
+        tar xf u-boot.tar.bz2 --strip-components=1
+      - |
+        make soquartz-cm4-rk3566_defconfig
+    # use binary firmware, pending ATF support
+    # https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/16952
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" BL31=/libs/rkbin/bin/rk35/rk3568_bl31_v1.44.elf ROCKCHIP_TPL=/libs/rkbin/bin/rk35/rk3566_ddr_1056MHz_v1.21.bin SCP=/dev/null
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/soquartz-cm4
+        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/soquartz-cm4
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/go.work
+++ b/go.work
@@ -7,4 +7,5 @@ use (
 	./installers/rockpi4/src
 	./installers/rockpi4c/src
 	./installers/rock4cplus/src
+	./installers/soquartz-cm4/src
 )

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -8,6 +8,7 @@ dependencies:
   - stage: rockpi4
   - stage: rockpi4c
   - stage: rock4cplus
+  - stage: soquartz-cm4
   - stage: profiles
   - stage: u-boot-nanopi-r4s
     platform: linux/arm64
@@ -20,6 +21,8 @@ dependencies:
   - stage: u-boot-rockpi4c
     platform: linux/arm64
   - stage: u-boot-rock4cplus
+    platform: linux/arm64
+  - stage: u-boot-soquartz-cm4
     platform: linux/arm64
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
     platform: linux/arm64
@@ -45,6 +48,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-rock-4c-plus.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3399-rock-4c-plus.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3566-soquartz-cm4.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3566-soquartz-cm4.dtb
 finalize:
   - from: /rootfs
     to: /

--- a/installers/soquartz-cm4/pkg.yaml
+++ b/installers/soquartz-cm4/pkg.yaml
@@ -1,0 +1,25 @@
+name: soquartz-cm4
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /go
+    cachePaths:
+      - /.cache/go-build
+      - /go/pkg
+    build:
+      - |
+        export PATH=${PATH}:${TOOLCHAIN}/go/bin
+
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./soquartz-cm4 .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp /pkg/src/soquartz-cm4 /rootfs/installers/soquartz-cm4
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/soquartz-cm4/src/go.mod
+++ b/installers/soquartz-cm4/src/go.mod
@@ -1,0 +1,11 @@
+module soquartz-cm4
+
+go 1.22.1
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.7.0-alpha.1
+	golang.org/x/sys v0.16.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/soquartz-cm4/src/go.sum
+++ b/installers/soquartz-cm4/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.7.0-alpha.1 h1:0pURmnbzsu19reku8OjN1DkeAxgkmuxmKgDgbFT3228=
+github.com/siderolabs/talos/pkg/machinery v1.7.0-alpha.1/go.mod h1:H2+5QeGXYi2Q7RhBNUAD6dhc9LmdJ2AUXtiAWRXtWBc=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/soquartz-cm4/src/main.go
+++ b/installers/soquartz-cm4/src/main.go
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const off int64 = 512 * 64
+
+func main() {
+	adapter.Execute(&soquartzCM4{})
+}
+
+type soquartzCM4 struct{}
+
+type soquartzCM4ExtraOptions struct{}
+
+func (i *soquartzCM4) GetOptions(extra soquartzCM4ExtraOptions) (overlay.Options, error) {
+	kernelArgs := []string{
+		"console=tty0",
+		"console=ttyS2,1500000n8",
+		"sysctl.kernel.kexec_load_disabled=1",
+		"talos.dashboard.disabled=1",
+	}
+
+	return overlay.Options{
+		Name:       "soquartz-cm4",
+		KernelArgs: kernelArgs,
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *soquartzCM4) Install(options overlay.InstallOptions[soquartzCM4ExtraOptions]) error {
+	var f *os.File
+
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", options.InstallDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/soquartz-cm4/u-boot-rockchip.bin"))
+	if err != nil {
+		return err
+	}
+
+	// we need an offset so can't use copy.File
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to esure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	// allows to copy a directory from the overlay to the target
+	return copy.Dir(filepath.Join(options.ArtifactsPath, "arm64/dtb"), filepath.Join(options.MountPrefix, "/boot/EFI/dtb"))
+}

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -13,3 +13,5 @@ finalize:
     to: /rootfs/profiles
   - from: /pkg/rock4cplus
     to: /rootfs/profiles
+  - from: /pkg/soquartz-cm4
+    to: /rootfs/profiles

--- a/profiles/soquartz-cm4/soquartz-cm4.yaml
+++ b/profiles/soquartz-cm4/soquartz-cm4.yaml
@@ -1,0 +1,9 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw


### PR DESCRIPTION
An RK3566-based compute module in the RPi CM4 form factor. Leaving as draft until I have time to test the latest TPL/ATF. Could also move `rkbin` to a standalone artifact for reuse