### PR TITLE
feat: support `orangepi-r1-plus-lts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This repo provides the overlay for RockChip based Talos image.
 
 ## Supported Overlay
 
-| Overlay Name | Board                 | Description                                   |
-| ------------ | --------------------- | --------------------------------------------- |
-| nanopi-r4s   | NanoPi R4S            | Overlay for NanoPi R4S                        |
-| rock64       | Pine64 Rock64         | Overlay for Pine64 Rock64                     |
-| rockpi4      | Rock Pi 4A,Rock Pi 4B | Generic overlay for Rock Pi 4A and Rock Pi 4B |
-| rockpi4c     | Rock Pi 4C            | Overlay for Rock Pi 4C                        |
-| rock4cplus   | Radxa ROCK 4C+        | Overlay for Radxa ROCK 4C+                    |
+| Overlay Name         | Board                 | Description                                   |
+| -------------------- | --------------------- | --------------------------------------------- |
+| nanopi-r4s           | NanoPi R4S            | Overlay for NanoPi R4S                        |
+| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | Overlay for Orange Pi R1 Plus LTS             |
+| rock64               | Pine64 Rock64         | Overlay for Pine64 Rock64                     |
+| rockpi4              | Rock Pi 4A,Rock Pi 4B | Generic overlay for Rock Pi 4A and Rock Pi 4B |
+| rockpi4c             | Rock Pi 4C            | Overlay for Rock Pi 4C                        |
+| rock4cplus           | Radxa ROCK 4C+        | Overlay for Radxa ROCK 4C+                    |

--- a/artifacts/orangepi-r1-plus-lts/u-boot/pkg.yaml
+++ b/artifacts/orangepi-r1-plus-lts/u-boot/pkg.yaml
@@ -1,0 +1,41 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-orangepi-r1-plus-lts
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: arm-trusted-firmware-rk3328
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_sha256 }}"
+        sha512: "{{ .uboot_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      # orangepi-r1-plus-lts-rk3328
+      - |
+        mkdir -p /usr/bin \
+          && ln -sf /toolchain/bin/env /usr/bin/env \
+          && ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install pyelftools
+
+        tar xf u-boot.tar.bz2 --strip-components=1
+      - |
+        make orangepi-r1-plus-lts-rk3328_defconfig
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" BL31=/libs/arm-trusted-firmware/rk3328/bl31.elf \
+          CONFIG_USB_HOST_ETHER=y \
+          CONFIG_USB_ETHER_RTL8152=y
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/orangepi-r1-plus-lts
+        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/orangepi-r1-plus-lts
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/go.work
+++ b/go.work
@@ -2,6 +2,7 @@ go 1.22.1
 
 use (
 	./installers/nanopi-r4s/src
+	./installers/orangepi-r1-plus-lts/src
 	./installers/rock64/src
 	./installers/rockpi4/src
 	./installers/rockpi4c/src

--- a/installers/orangepi-r1-plus-lts/pkg.yaml
+++ b/installers/orangepi-r1-plus-lts/pkg.yaml
@@ -1,0 +1,25 @@
+name: orangepi-r1-plus-lts
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /go
+    cachePaths:
+      - /.cache/go-build
+      - /go/pkg
+    build:
+      - |
+        export PATH=${PATH}:${TOOLCHAIN}/go/bin
+
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./orangepi-r1-plus-lts .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp /pkg/src/orangepi-r1-plus-lts /rootfs/installers/orangepi-r1-plus-lts
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/orangepi-r1-plus-lts/src/go.mod
+++ b/installers/orangepi-r1-plus-lts/src/go.mod
@@ -1,0 +1,11 @@
+module orangepi-r1-plus-lts
+
+go 1.22.1
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.7.0-alpha.1
+	golang.org/x/sys v0.16.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/orangepi-r1-plus-lts/src/go.sum
+++ b/installers/orangepi-r1-plus-lts/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.7.0-alpha.1 h1:0pURmnbzsu19reku8OjN1DkeAxgkmuxmKgDgbFT3228=
+github.com/siderolabs/talos/pkg/machinery v1.7.0-alpha.1/go.mod h1:H2+5QeGXYi2Q7RhBNUAD6dhc9LmdJ2AUXtiAWRXtWBc=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/orangepi-r1-plus-lts/src/main.go
+++ b/installers/orangepi-r1-plus-lts/src/main.go
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	off int64 = 512 * 64
+	dtb       = "rockchip/rk3328-orangepi-r1-plus-lts.dtb"
+)
+
+func main() {
+	adapter.Execute(&opiR1PlusLTS{})
+}
+
+type opiR1PlusLTS struct{}
+
+type opiR1PlusLTSExtraOptions struct{}
+
+func (i *opiR1PlusLTS) GetOptions(extra opiR1PlusLTSExtraOptions) (overlay.Options, error) {
+	return overlay.Options{
+		Name: "orangepi-r1-plus-lts",
+		KernelArgs: []string{
+			"console=tty0",
+			"console=ttyS2,1500000n8",
+			"sysctl.kernel.kexec_load_disabled=1",
+			"talos.dashboard.disabled=1",
+		},
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *opiR1PlusLTS) Install(options overlay.InstallOptions[opiR1PlusLTSExtraOptions]) error {
+	var f *os.File
+
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", options.InstallDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/orangepi-r1-plus-lts/u-boot-rockchip.bin"))
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to esure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	return copy.File(src, dst)
+}

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -3,11 +3,14 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: nanopi-r4s
+  - stage: orangepi-r1-plus-lts
   - stage: rock64
   - stage: rockpi4
   - stage: rockpi4c
   - stage: profiles
   - stage: u-boot-nanopi-r4s
+    platform: linux/arm64
+  - stage: u-boot-orangepi-r1-plus-lts
     platform: linux/arm64
   - stage: u-boot-rock64
     platform: linux/arm64
@@ -21,6 +24,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-nanopi-r4s.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3399-nanopi-r4s.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3328-orangepi-r1-plus-lts.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3328-orangepi-r1-plus-lts.dtb
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
     platform: linux/arm64
     from: /dtb/rockchip/rk3328-rock64.dtb

--- a/profiles/orangepi-r1-plus-lts/orangepi-r1-plus-lts.yaml
+++ b/profiles/orangepi-r1-plus-lts/orangepi-r1-plus-lts.yaml
@@ -1,0 +1,9 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -3,6 +3,8 @@ variant: scratch
 finalize:
   - from: /pkg/nanopi-r4s
     to: /rootfs/profiles
+  - from: /pkg/orangepi-r1-plus-lts
+    to: /rootfs/profiles
   - from: /pkg/rock64
     to: /rootfs/profiles
   - from: /pkg/rockpi4


### PR DESCRIPTION
Build a Talos overlay for the OrangePi R1 Plus LTS SBC.