### PR TITLE
fix: rock4cplus build and missing from installers

### DIFF
--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -7,6 +7,7 @@ dependencies:
   - stage: rock64
   - stage: rockpi4
   - stage: rockpi4c
+  - stage: rock4cplus
   - stage: profiles
   - stage: u-boot-nanopi-r4s
     platform: linux/arm64

--- a/installers/rock4cplus/src/main.go
+++ b/installers/rock4cplus/src/main.go
@@ -45,7 +45,7 @@ func (i *rock4cplus) GetOptions(extra rock4cplusExtraOptions) (overlay.Options, 
 	}, nil
 }
 
-func (i *rock4cplus) Install(options overlay.InstallOptions[rockPi4cExtraOptions]) error {
+func (i *rock4cplus) Install(options overlay.InstallOptions[rock4cplusExtraOptions]) error {
 	var f *os.File
 
 	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)


### PR DESCRIPTION
Fixes #10. [Passed CI](https://github.com/pl4nty/talos-sbc-rockchip/actions/runs/8586147338) with:

```
docker run --rm -t -v $PWD/_out:/out -v /dev:/dev --privileged ghcr.io/pl4nty/imager:v1.7.0 metal --arch arm64 \
  --overlay-name rock4cplus --overlay-image ghcr.io/pl4nty/sbc-rockchip:v1.7.0 \
  --system-extension-image ghcr.io/siderolabs/iscsi-tools:v0.1.4 \
  --system-extension-image ghcr.io/siderolabs/util-linux-tools:2.39.3
```