### PR TITLE
fix(nanopi-r4s): fix u-boot path in installer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+- [Overview](#overview)
+- [Current Maintainers](#current-maintainers)
+
+## Overview
+
+This document contains a list of maintainers in this repo. For now, you become a maintainer if you submit a PR that adds a new board. You are responsible for testing the overlay on the board you added.
+
+## Current Maintainers
+
+| Overlay Name         | Board                 | PR                                                        | SoC    | Maintainer                       | GitHub ID                                     |
+| -------------------- | --------------------- | --------------------------------------------------------- | ------ | -------------------------------- | --------------------------------------------- |
+| nanopi-r4s           | NanoPi R4S            | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3399 | TBD (Initial PR moved from pkgs) | [frezbo](https://github.com/frezbo)           |
+| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | [#9](https://github.com/siderolabs/sbc-rockchip/pull/9)   | RK3328 | Giau. Tran Minh                  | [giautm](https://github.com/giautm)           |
+| rock64               | Pine64 Rock64         | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3328 | TBD (Initial PR moved from pkgs) | [frezbo](https://github.com/frezbo)           |
+| rockpi4              | Rock Pi 4A,Rock Pi 4B | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399 | TBD (Initial PR moved from pkgs) | [frezbo](https://github.com/frezbo)           |
+| rockpi4c             | Rock Pi 4C            | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399 | TBD (Initial PR moved from pkgs) | [frezbo](https://github.com/frezbo)           |
+| rock4cplus           | Radxa ROCK 4C+        | [#5](https://github.com/siderolabs/sbc-rockchip/pull/5)   | RK3399 | Damià Poquet Femenia             | [DamiaPoquet](https://github.com/DamiaPoquet) |
+| rock4se              | Radxa ROCK 4SE        | [#18](https://github.com/siderolabs/sbc-rockchip/pull/18) | RK3399 | Boran Car                        | [borancar](https://github.com/borancar)       |
+| helios64             | Kobol Helios64        | [#23](https://github.com/siderolabs/sbc-rockchip/pull/23) | RK3399 | Hemanth Bollamreddi              | [blmhemu](https://github.com/blmhemu)         |

--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ This repo provides the overlay for RockChip based Talos image.
 
 ## Supported Overlay
 
-| Overlay Name         | Board                 | Description                                   |
-| -------------------- | --------------------- | --------------------------------------------- |
-| nanopi-r4s           | NanoPi R4S            | Overlay for NanoPi R4S                        |
-| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | Overlay for Orange Pi R1 Plus LTS             |
-| rock64               | Pine64 Rock64         | Overlay for Pine64 Rock64                     |
-| rockpi4              | Rock Pi 4A,Rock Pi 4B | Generic overlay for Rock Pi 4A and Rock Pi 4B |
-| rockpi4c             | Rock Pi 4C            | Overlay for Rock Pi 4C                        |
-| rock4cplus           | Radxa ROCK 4C+        | Overlay for Radxa ROCK 4C+                    |
-| rock4se              | Radxa ROCK 4SE        | Overlay for Radxa ROCK 4SE                    |
-| helios64             | Kobol Helios64        | Overlay for Kobol Helios64                    |
+| Overlay Name         | Board                 | SoC    | Description                                   |
+| -------------------- | --------------------- | ------ | --------------------------------------------- |
+| nanopi-r4s           | NanoPi R4S            | RK3399 | Overlay for NanoPi R4S                        |
+| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | RK3328 | Overlay for Orange Pi R1 Plus LTS             |
+| rock64               | Pine64 Rock64         | RK3328 | Overlay for Pine64 Rock64                     |
+| rockpi4              | Rock Pi 4A,Rock Pi 4B | RK3399 | Generic overlay for Rock Pi 4A and Rock Pi 4B |
+| rockpi4c             | Rock Pi 4C            | RK3399 | Overlay for Rock Pi 4C                        |
+| rock4cplus           | Radxa ROCK 4C+        | RK3399 | Overlay for Radxa ROCK 4C+                    |
+| helios64             | Kobol Helios64        | RK3399 | Overlay for Kobol Helios64                    |

--- a/installers/helios64/src/main.go
+++ b/installers/helios64/src/main.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
-	dtb       = "rockchip/rk3399-kobol-helios64.dtb"
+	off   int64 = 512 * 64
+	board       = "helios64"
+	dtb         = "rockchip/rk3399-kobol-helios64.dtb"
 )
 
 func main() {
@@ -31,7 +32,7 @@ type helios64ExtraOptions struct{}
 
 func (i *helios64) GetOptions(extra helios64ExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "helios64",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty1",
 			"console=ttyS2,1500000n8",
@@ -55,7 +56,7 @@ func (i *helios64) Install(options overlay.InstallOptions[helios64ExtraOptions])
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/helios64/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}

--- a/installers/nanopi-r4s/src/main.go
+++ b/installers/nanopi-r4s/src/main.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
-	dtb       = "rockchip/rk3399-nanopi-r4s.dtb"
+	off   int64 = 512 * 64
+	board       = "nanopi-r4s"
+	dtb         = "rockchip/rk3399-nanopi-r4s.dtb"
 )
 
 func main() {
@@ -31,7 +32,7 @@ type nanopir4sExtraOptions struct{}
 
 func (i *nanopir4s) GetOptions(extra nanopir4sExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "nanopi-r4s",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty0",
 			"console=ttyS2,1500000n8",
@@ -54,7 +55,7 @@ func (i *nanopir4s) Install(options overlay.InstallOptions[nanopir4sExtraOptions
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rockpi4/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}

--- a/installers/orangepi-r1-plus-lts/src/main.go
+++ b/installers/orangepi-r1-plus-lts/src/main.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
-	dtb       = "rockchip/rk3328-orangepi-r1-plus-lts.dtb"
+	off   int64 = 512 * 64
+	board       = "orangepi-r1-plus-lts"
+	dtb         = "rockchip/rk3328-orangepi-r1-plus-lts.dtb"
 )
 
 func main() {
@@ -31,7 +32,7 @@ type opiR1PlusLTSExtraOptions struct{}
 
 func (i *opiR1PlusLTS) GetOptions(extra opiR1PlusLTSExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "orangepi-r1-plus-lts",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty0",
 			"console=ttyS2,1500000n8",
@@ -54,7 +55,7 @@ func (i *opiR1PlusLTS) Install(options overlay.InstallOptions[opiR1PlusLTSExtraO
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/orangepi-r1-plus-lts/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}

--- a/installers/rock4cplus/src/main.go
+++ b/installers/rock4cplus/src/main.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
+	off   int64 = 512 * 64
+	board       = "rock4cplus"
 	// https://github.com/u-boot/u-boot/blob/abd4fb5ac13215733569925a06991e0a182ede14/configs/rock-4c-plus-rk3399_defconfig#L22
 	dtb = "rockchip/rk3399-rock-4c-plus.dtb"
 )
@@ -32,7 +33,7 @@ type rock4cplusExtraOptions struct{}
 
 func (i *rock4cplus) GetOptions(extra rock4cplusExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "rock4cplus",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty0",
 			"console=ttyS2,1500000n8",
@@ -55,7 +56,7 @@ func (i *rock4cplus) Install(options overlay.InstallOptions[rock4cplusExtraOptio
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rock4cplus/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}

--- a/installers/rock4se/src/main.go
+++ b/installers/rock4se/src/main.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
+	off   int64 = 512 * 64
+	board       = "rock4se"
 	// https://github.com/u-boot/u-boot/blob/4de720e98d552dfda9278516bf788c4a73b3e56f/configs/rock-pi-4c-rk3399_defconfig#L7=
 	dtb = "rockchip/rk3399-rock-4se.dtb"
 )
@@ -32,7 +33,7 @@ type rock4seExtraOptions struct{}
 
 func (i *rock4se) GetOptions(extra rock4seExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "rock4se",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty0",
 			"console=ttyS2,1500000n8",
@@ -55,7 +56,7 @@ func (i *rock4se) Install(options overlay.InstallOptions[rock4seExtraOptions]) e
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rock4se/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}

--- a/installers/rock64/src/main.go
+++ b/installers/rock64/src/main.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
-	dtb       = "rockchip/rk3328-rock64.dtb"
+	off   int64 = 512 * 64
+	board       = "rock64"
+	dtb         = "rockchip/rk3328-rock64.dtb"
 )
 
 func main() {
@@ -31,7 +32,7 @@ type rock64ExtraOptions struct{}
 
 func (i *rock64) GetOptions(extra rock64ExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "rock64",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty0",
 			"ttyS2,115200n8",
@@ -54,7 +55,7 @@ func (i *rock64) Install(options overlay.InstallOptions[rock64ExtraOptions]) err
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rock64/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}

--- a/installers/rockpi4/src/main.go
+++ b/installers/rockpi4/src/main.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
+	off   int64 = 512 * 64
+	board       = "rockpi4"
 	// https://github.com/u-boot/u-boot/blob/4de720e98d552dfda9278516bf788c4a73b3e56f/configs/rock-pi-4-rk3399_defconfig#L7=
 	// 4a and 4b uses the same overlay.
 	dtb = "rockchip/rk3399-rock-pi-4b.dtb"
@@ -33,7 +34,7 @@ type rockPi4ExtraOptions struct{}
 
 func (i *rockPi4) GetOptions(extra rockPi4ExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "rockpi4",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty0",
 			"console=ttyS2,1500000n8",
@@ -56,7 +57,7 @@ func (i *rockPi4) Install(options overlay.InstallOptions[rockPi4ExtraOptions]) e
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rockpi4/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}

--- a/installers/rockpi4c/src/main.go
+++ b/installers/rockpi4c/src/main.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	off int64 = 512 * 64
+	off   int64 = 512 * 64
+	board       = "rockpi4c"
 	// https://github.com/u-boot/u-boot/blob/4de720e98d552dfda9278516bf788c4a73b3e56f/configs/rock-pi-4c-rk3399_defconfig#L7=
 	dtb = "rockchip/rk3399-rock-pi-4c.dtb"
 )
@@ -32,7 +33,7 @@ type rockPi4cExtraOptions struct{}
 
 func (i *rockPi4c) GetOptions(extra rockPi4cExtraOptions) (overlay.Options, error) {
 	return overlay.Options{
-		Name: "rockpi4c",
+		Name: board,
 		KernelArgs: []string{
 			"console=tty0",
 			"console=ttyS2,1500000n8",
@@ -55,7 +56,7 @@ func (i *rockPi4c) Install(options overlay.InstallOptions[rockPi4cExtraOptions])
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rockpi4c/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes the incorrect installer path mentioned in PR #16. 

You may notice that I created a board variable. Should I do that for all installers to make it simpler to create new ones and prevent errors like this in the future?

For your reference @frezbo.

Please note that I have no way of testing this. In relation to this, would it make sense to reference a contact person for each board in the README.md. I have noticed that [Armbian](https://www.armbian.com/) does something similar.