### PR TITLE
fix(nanopi-r5s): avoid broken NVMe

### DIFF
--- a/artifacts/nanopi-r5s/u-boot/patches/uboot-defconfig.patch
+++ b/artifacts/nanopi-r5s/u-boot/patches/uboot-defconfig.patch
@@ -1,0 +1,10 @@
+diff --git a/configs/nanopi-r5s-rk3568_defconfig b/configs/nanopi-r5s-rk3568_defconfig
+index 7ab12e619a..399b73fa75 100644
+--- a/configs/nanopi-r5s-rk3568_defconfig
++++ b/configs/nanopi-r5s-rk3568_defconfig
+@@ -76,3 +76,5 @@ CONFIG_USB_OHCI_GENERIC=y
+ CONFIG_USB_DWC3=y
+ CONFIG_USB_DWC3_GENERIC=y
+ CONFIG_ERRNO_STR=y
++CONFIG_USE_PREBOOT=y
++CONFIG_PREBOOT="led led-power on; led led-lan1 on; led led-lan2 on; led led-wan on; pci enum; nvme scan; led led-lan1 off; led led-lan2 off; led led-wan off"

--- a/artifacts/nanopi-r5s/u-boot/patches/uboot-led-triggers.patch
+++ b/artifacts/nanopi-r5s/u-boot/patches/uboot-led-triggers.patch
@@ -1,0 +1,20 @@
+diff --git a/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi b/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi
+index 64c43374c0..98fea57d8a 100644
+--- a/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi
++++ b/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi
+@@ -24,3 +24,15 @@
+        /delete-property/ regulator-always-on;
+        /delete-property/ regulator-boot-on;
+ };
++
++&{/gpio-leds/led-wan} {
++               linux,default-trigger = "stmmac-0:01:link";
++};
++
++&{/gpio-leds/led-lan1} {
++               linux,default-trigger = "r8169-0-100:00:link";
++};
++
++&{/gpio-leds/led-lan2} {
++               linux,default-trigger = "r8169-1-100:00:link";
++};

--- a/artifacts/nanopi-r5s/u-boot/pkg.yaml
+++ b/artifacts/nanopi-r5s/u-boot/pkg.yaml
@@ -28,6 +28,10 @@ steps:
         tar xf u-boot.tar.bz2 --strip-components=1
 
         patch -p1 < /pkg/patches/uboot-byteorder.patch
+
+        patch -p1 < /pkg/patches/uboot-defconfig.patch
+
+        patch -p1 < /pkg/patches/uboot-led-triggers.patch
       - |
         make nanopi-r5s-rk3568_defconfig
     build:


### PR DESCRIPTION
This attempts to fix the broken NVMe for the Nano Pi R5S.

References:
- armbian/build#6896

Tasks:
- [ ] Test preboot if preboot command only affects NVMe
- [ ] Compare `.dts`  files
