### PR TITLE
feat: add ROCK 5B support

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,4 +17,5 @@ This document contains a list of maintainers in this repo. For now, you become a
 | rockpi4c             | Rock Pi 4C            | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399 | TBD (Initial PR moved from pkgs) | TBD                                             |
 | rock4cplus           | Radxa ROCK 4C+        | [#5](https://github.com/siderolabs/sbc-rockchip/pull/5)   | RK3399 | Damià Poquet Femenia             | [DamiaPoquet](https://github.com/DamiaPoquet)   |
 | rock4se              | Radxa ROCK 4SE        | [#18](https://github.com/siderolabs/sbc-rockchip/pull/18) | RK3399 | Boran Car                        | [borancar](https://github.com/borancar)         |
+| rock5b               | Radxa ROCK 5B         | [#45](https://github.com/siderolabs/sbc-rockchip/pull/45) | RK3588 | Christoph Hoopmann               | [choopm](https://github.com/choopm)             |
 | helios64             | Kobol Helios64        | [#23](https://github.com/siderolabs/sbc-rockchip/pull/23) | RK3399 | Hemanth Bollamreddi              | [blmhemu](https://github.com/blmhemu)           |

--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ This repo provides the overlay for RockChip based Talos image.
 | rockpi4c             | Rock Pi 4C            | RK3399 | Overlay for Rock Pi 4C                        |
 | rock4se              | Rock 4 SE             | RK3399 | Overlay for Rock 4 SE                         |
 | rock4cplus           | Radxa ROCK 4C+        | RK3399 | Overlay for Radxa ROCK 4C+                    |
+| rock5b               | Radxa ROCK 5B         | RK3588 | Overlay for Radxa ROCK 5B                     |
 | turingrk1            | Turing Machines RK1   | RK3588 | Overlay for Turing Machines RK1               |

--- a/artifacts/rock5b/u-boot/patches/uboot-byteorder.patch
+++ b/artifacts/rock5b/u-boot/patches/uboot-byteorder.patch
@@ -1,0 +1,15 @@
+diff --git a/include/linux/byteorder/little_endian.h b/include/linux/byteorder/little_endian.h
+index a4cb3bfde5..0ecd088f4a 100644
+--- a/include/linux/byteorder/little_endian.h
++++ b/include/linux/byteorder/little_endian.h
+@@ -7,7 +7,10 @@
+ #ifndef __LITTLE_ENDIAN_BITFIELD
+ #define __LITTLE_ENDIAN_BITFIELD
+ #endif
++
++#ifndef __BYTE_ORDER
+ #define	__BYTE_ORDER	__LITTLE_ENDIAN
++#endif
+ 
+ #include <linux/compiler.h>
+ #include <linux/types.h>

--- a/artifacts/rock5b/u-boot/pkg.yaml
+++ b/artifacts/rock5b/u-boot/pkg.yaml
@@ -1,0 +1,44 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-rock5b
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: arm-trusted-firmware-rk3588
+  - stage: rkbin-rk3588
+    platform: linux/amd64
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_rk1_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_rk1_sha256 }}"
+        sha512: "{{ .uboot_rk1_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      # rock-5b-rk3588
+      - |
+        mkdir -p /usr/bin \
+          && ln -sf /toolchain/bin/env /usr/bin/env \
+          && ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install pyelftools setuptools \
+          && ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        tar xf u-boot.tar.bz2 --strip-components=1
+
+        patch -p1 < /pkg/patches/uboot-byteorder.patch
+      - |
+        make rock5b-rk3588_defconfig
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" BL31=/libs/arm-trusted-firmware/rk3588/bl31.elf ROCKCHIP_TPL=/libs/rkbin/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.18.bin
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/rock5b
+        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/rock5b
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/artifacts/rock5b/vars.yaml
+++ b/artifacts/rock5b/vars.yaml
@@ -1,0 +1,2 @@
+# renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
+WOLFI_BASE_REF: sha256:8dd9ceace8b1574e550374e9c07c2baafa60cc96223c1314fac61bd2edb48c70

--- a/go.work
+++ b/go.work
@@ -10,5 +10,6 @@ use (
 	./installers/rockpi4c/src
 	./installers/rock4cplus/src
 	./installers/rock4se/src
+	./installers/rock5b/src
 	./installers/turingrk1/src
 )

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -11,6 +11,7 @@ dependencies:
   - stage: rockpi4c
   - stage: rock4cplus
   - stage: rock4se
+  - stage: rock5b
   - stage: turingrk1
   - stage: profiles
   - stage: u-boot-helios64
@@ -30,6 +31,8 @@ dependencies:
   - stage: u-boot-rock4cplus
     platform: linux/arm64
   - stage: u-boot-rock4se
+    platform: linux/arm64
+  - stage: u-boot-rock5b
     platform: linux/arm64
   - stage: u-boot-turingrk1
     platform: linux/arm64
@@ -69,6 +72,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-rock-4se.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3399-rock-4se.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3588-rock-5b.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3588-rock-5b.dtb
   - stage: dtb-turingrk1
     platform: linux/arm64
     from: /dtb/rockchip/rk3588-turing-rk1.dtb

--- a/installers/rock5b/pkg.yaml
+++ b/installers/rock5b/pkg.yaml
@@ -1,0 +1,25 @@
+name: rock5b
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /go
+    cachePaths:
+      - /.cache/go-build
+      - /go/pkg
+    build:
+      - |
+        export PATH=${PATH}:${TOOLCHAIN}/go/bin
+
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./rock5b .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp /pkg/src/rock5b /rootfs/installers/rock5b
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/rock5b/src/go.mod
+++ b/installers/rock5b/src/go.mod
@@ -1,0 +1,11 @@
+module rock5b
+
+go 1.23.0
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.8.3
+	golang.org/x/sys v0.27.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/rock5b/src/go.sum
+++ b/installers/rock5b/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.8.3 h1:raK1oLzSMpwpy/AqkeFyBYkJS+QuOnlRMznVl/rZ25k=
+github.com/siderolabs/talos/pkg/machinery v1.8.3/go.mod h1:cNR2TELu2T9AzYOHAoNr/7ZS3ZVDLzM/KnuOr4XW4s4=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/rock5b/src/main.go
+++ b/installers/rock5b/src/main.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	off   int64 = 512 * 64
+	board       = "rock5b"
+	dtb         = "rockchip/rk3588-rock-5b.dtb"
+)
+
+func main() {
+	adapter.Execute(&rock5b{})
+}
+
+type rock5b struct{}
+
+type rock5bExtraOptions struct{}
+
+func (i *rock5b) GetOptions(extra rock5bExtraOptions) (overlay.Options, error) {
+	return overlay.Options{
+		Name: board,
+		KernelArgs: []string{
+			"cma=128MB",
+			"console=tty0",
+			"console=ttyS9,115200",
+			"console=ttyS2,115200",
+			"sysctl.kernel.kexec_load_disabled=1",
+			"talos.dashboard.disabled=1",
+		},
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *rock5b) Install(options overlay.InstallOptions[rock5bExtraOptions]) error {
+	var f *os.File
+
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", options.InstallDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to esure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	return copy.File(src, dst)
+}

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -19,5 +19,7 @@ finalize:
     to: /rootfs/profiles
   - from: /pkg/rock4se
     to: /rootfs/profiles
+  - from: /pkg/rock5b
+    to: /rootfs/profiles
   - from: /pkg/turingrk1
     to: /rootfs/profiles

--- a/profiles/rock5b/rock5b.yaml
+++ b/profiles/rock5b/rock5b.yaml
@@ -1,0 +1,9 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw


### PR DESCRIPTION
This adds support for RADXA ROCK 5B SBC.
It reuses rkbin-rk3588 and also builds the more recent u-boot-2024.10 as Turing RK1.

I'm currently updating a six node cluster for testing. Will inform you on the results.

You can test it using my installer image: `ghcr.io/choopm/talos-rock5b:v1.9.1`
The installer image was built using:

```shell
# build installer image
docker run --rm -t -v ./_out:/out -v /dev:/dev --privileged \
  ghcr.io/siderolabs/imager:v1.9.1 \
  installer --arch arm64 \
    --base-installer-image="ghcr.io/siderolabs/installer:v1.9.1" \
    --overlay-image=ghcr.io/choopm/sbc-rockchip:v1.9.1 \
    --overlay-name=rock5b \
    --system-extension-image="ghcr.io/siderolabs/iscsi-tools:v0.1.6@sha256:5adbd9bd67ffa39f65d0e5e534edadc904dd58e7e405ff7509889fd3d006ad18" \
    --system-extension-image="ghcr.io/siderolabs/realtek-firmware:20241210@sha256:45931337d8199240b9afb4518872d4e493339854c2d85200f53313dad769e627"

# push installer image
crane push _out/installer-arm64.tar ghcr.io/choopm/talos-rock5b:v1.9.1
```

Let me know what you think.