### PR TITLE
add orangepi-5 support

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,15 +7,16 @@ This document contains a list of maintainers in this repo. For now, you become a
 
 ## Current Maintainers
 
-| Overlay Name         | Board                 | PR                                                        | SoC    | Maintainer                       | GitHub ID                                       |
-| -------------------- | --------------------- | --------------------------------------------------------- | ------ | -------------------------------- | ----------------------------------------------- |
-| nanopi-r4s           | NanoPi R4S            | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3399 | TBD (Initial PR moved from pkgs) | TBD                                             |
-| nanopi-r5s           | NanoPi R5S            | [#16](https://github.com/siderolabs/sbc-rockchip/pull/16) | RK3568 | Nicklas Frahm                    | [nicklasfrahm](https://github.com/nicklasfrahm) |
-| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | [#9](https://github.com/siderolabs/sbc-rockchip/pull/9)   | RK3328 | Giau. Tran Minh                  | [giautm](https://github.com/giautm)             |
-| rock64               | Pine64 Rock64         | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3328 | TBD (Initial PR moved from pkgs) | TBD                                             |
-| rockpi4              | Rock Pi 4A,Rock Pi 4B | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399 | TBD (Initial PR moved from pkgs) | TBD                                             |
-| rockpi4c             | Rock Pi 4C            | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399 | TBD (Initial PR moved from pkgs) | TBD                                             |
-| rock4cplus           | Radxa ROCK 4C+        | [#5](https://github.com/siderolabs/sbc-rockchip/pull/5)   | RK3399 | Damià Poquet Femenia             | [DamiaPoquet](https://github.com/DamiaPoquet)   |
-| rock4se              | Radxa ROCK 4SE        | [#18](https://github.com/siderolabs/sbc-rockchip/pull/18) | RK3399 | Boran Car                        | [borancar](https://github.com/borancar)         |
-| rock5b               | Radxa ROCK 5B         | [#45](https://github.com/siderolabs/sbc-rockchip/pull/45) | RK3588 | Christoph Hoopmann               | [choopm](https://github.com/choopm)             |
-| helios64             | Kobol Helios64        | [#23](https://github.com/siderolabs/sbc-rockchip/pull/23) | RK3399 | Hemanth Bollamreddi              | [blmhemu](https://github.com/blmhemu)           |
+| Overlay Name         | Board                 | PR                                                        | SoC     | Maintainer                       | GitHub ID                                       |
+| -------------------- | --------------------- | --------------------------------------------------------- | ------- | -------------------------------- | ----------------------------------------------- |
+| nanopi-r4s           | NanoPi R4S            | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
+| nanopi-r5s           | NanoPi R5S            | [#16](https://github.com/siderolabs/sbc-rockchip/pull/16) | RK3568  | Nicklas Frahm                    | [nicklasfrahm](https://github.com/nicklasfrahm) |
+| orangepi-5           | Orange Pi 5           | [#47](https://github.com/siderolabs/sbc-rockchip/pull/47) | RK3588s | Laurin Streng                    | [laurinstreng](https://github.com/LaurinStreng) |
+| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | [#9](https://github.com/siderolabs/sbc-rockchip/pull/9)   | RK3328  | Giau. Tran Minh                  | [giautm](https://github.com/giautm)             |
+| rock64               | Pine64 Rock64         | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3328  | TBD (Initial PR moved from pkgs) | TBD                                             |
+| rockpi4              | Rock Pi 4A,Rock Pi 4B | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
+| rockpi4c             | Rock Pi 4C            | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
+| rock4cplus           | Radxa ROCK 4C+        | [#5](https://github.com/siderolabs/sbc-rockchip/pull/5)   | RK3399  | Damià Poquet Femenia             | [DamiaPoquet](https://github.com/DamiaPoquet)   |
+| rock4se              | Radxa ROCK 4SE        | [#18](https://github.com/siderolabs/sbc-rockchip/pull/18) | RK3399  | Boran Car                        | [borancar](https://github.com/borancar)         |
+| rock5b               | Radxa ROCK 5B         | [#45](https://github.com/siderolabs/sbc-rockchip/pull/45) | RK3588  | Christoph Hoopmann               | [choopm](https://github.com/choopm)             |
+| helios64             | Kobol Helios64        | [#23](https://github.com/siderolabs/sbc-rockchip/pull/23) | RK3399  | Hemanth Bollamreddi              | [blmhemu](https://github.com/blmhemu)           |

--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ This repo provides the overlay for RockChip based Talos image.
 
 ## Supported Overlay
 
-| Overlay Name         | Board                 | SoC    | Description                                   |
-| -------------------- | --------------------- | ------ | --------------------------------------------- |
-| helios64             | Kobol Helios64        | RK3399 | Overlay for Kobol Helios64                    |
-| nanopi-r5s           | NanoPi R5S            | RK3568 | Overlay for NanoPi R5S (only WAN, no NVMe)    |
-| nanopi-r4s           | NanoPi R4S            | RK3399 | Overlay for NanoPi R4S                        |
-| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | RK3328 | Overlay for Orange Pi R1 Plus LTS             |
-| rock64               | Pine64 Rock64         | RK3328 | Overlay for Pine64 Rock64                     |
-| rockpi4              | Rock Pi 4A,Rock Pi 4B | RK3399 | Generic overlay for Rock Pi 4A and Rock Pi 4B |
-| rockpi4c             | Rock Pi 4C            | RK3399 | Overlay for Rock Pi 4C                        |
-| rock4se              | Rock 4 SE             | RK3399 | Overlay for Rock 4 SE                         |
-| rock4cplus           | Radxa ROCK 4C+        | RK3399 | Overlay for Radxa ROCK 4C+                    |
-| rock5b               | Radxa ROCK 5B         | RK3588 | Overlay for Radxa ROCK 5B                     |
-| turingrk1            | Turing Machines RK1   | RK3588 | Overlay for Turing Machines RK1               |
+| Overlay Name         | Board                 | SoC     | Description                                   |
+| -------------------- | --------------------- | ------- | --------------------------------------------- |
+| helios64             | Kobol Helios64        | RK3399  | Overlay for Kobol Helios64                    |
+| nanopi-r5s           | NanoPi R5S            | RK3568  | Overlay for NanoPi R5S (only WAN, no NVMe)    |
+| nanopi-r4s           | NanoPi R4S            | RK3399  | Overlay for NanoPi R4S                        |
+| orangepi-5           | Orange Pi 5           | RK3588s | Overlay for Orange Pi 5                       |
+| orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | RK3328  | Overlay for Orange Pi R1 Plus LTS             |
+| rock64               | Pine64 Rock64         | RK3328  | Overlay for Pine64 Rock64                     |
+| rockpi4              | Rock Pi 4A,Rock Pi 4B | RK3399  | Generic overlay for Rock Pi 4A and Rock Pi 4B |
+| rockpi4c             | Rock Pi 4C            | RK3399  | Overlay for Rock Pi 4C                        |
+| rock4se              | Rock 4 SE             | RK3399  | Overlay for Rock 4 SE                         |
+| rock4cplus           | Radxa ROCK 4C+        | RK3399  | Overlay for Radxa ROCK 4C+                    |
+| rock5b               | Radxa ROCK 5B         | RK3588  | Overlay for Radxa ROCK 5B                     |
+| turingrk1            | Turing Machines RK1   | RK3588  | Overlay for Turing Machines RK1               |

--- a/artifacts/orangepi-5/u-boot/patches/uboot-byteorder.patch
+++ b/artifacts/orangepi-5/u-boot/patches/uboot-byteorder.patch
@@ -1,0 +1,15 @@
+diff --git a/include/linux/byteorder/little_endian.h b/include/linux/byteorder/little_endian.h
+index a4cb3bfde5..0ecd088f4a 100644
+--- a/include/linux/byteorder/little_endian.h
++++ b/include/linux/byteorder/little_endian.h
+@@ -7,7 +7,10 @@
+ #ifndef __LITTLE_ENDIAN_BITFIELD
+ #define __LITTLE_ENDIAN_BITFIELD
+ #endif
++
++#ifndef __BYTE_ORDER
+ #define	__BYTE_ORDER	__LITTLE_ENDIAN
++#endif
+ 
+ #include <linux/compiler.h>
+ #include <linux/types.h>

--- a/artifacts/orangepi-5/u-boot/pkg.yaml
+++ b/artifacts/orangepi-5/u-boot/pkg.yaml
@@ -1,0 +1,47 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-orangepi-5
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - stage: arm-trusted-firmware-rk3588
+  - stage: rkbin-rk3588
+    platform: linux/amd64
+
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_rk1_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_rk1_sha256 }}"
+        sha512: "{{ .uboot_rk1_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      # orangepi-5-rk3588s
+      - |
+        mkdir -p /usr/bin
+        ln -sf /toolchain/bin/env /usr/bin/env
+        ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install pyelftools setuptools
+
+        tar xf u-boot.tar.bz2 --strip-components=1
+
+        for patch in $(find /pkg/patches -type f -name "*.patch" | sort); do
+          echo "Applying $patch"
+          patch -p1 < $patch || (echo "Failed to apply patch $patch" && exit 1)
+        done
+      - |
+        make orangepi-5-rk3588s_defconfig
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" BL31=/libs/arm-trusted-firmware/rk3588/bl31.elf ROCKCHIP_TPL=/libs/rkbin/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.18.bin
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/orangepi-5
+        cp -v -t /rootfs/artifacts/arm64/u-boot/orangepi-5 u-boot-rockchip.bin
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/artifacts/orangepi-5/vars.yaml
+++ b/artifacts/orangepi-5/vars.yaml
@@ -1,0 +1,2 @@
+# renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
+WOLFI_BASE_REF: sha256:8dd9ceace8b1574e550374e9c07c2baafa60cc96223c1314fac61bd2edb48c70

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	./installers/helios64/src
 	./installers/nanopi-r5s/src
 	./installers/nanopi-r4s/src
+	./installers/orangepi-5/src
 	./installers/orangepi-r1-plus-lts/src
 	./installers/rock64/src
 	./installers/rockpi4/src

--- a/installers/orangepi-5/pkg.yaml
+++ b/installers/orangepi-5/pkg.yaml
@@ -1,0 +1,25 @@
+name: orangepi-5
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /go
+    cachePaths:
+      - /.cache/go-build
+      - /go/pkg
+    build:
+      - |
+        export PATH=${PATH}:${TOOLCHAIN}/go/bin
+
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./orangepi-5 .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp -p /pkg/src/orangepi-5 /rootfs/installers/orangepi-5
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/orangepi-5/src/go.mod
+++ b/installers/orangepi-5/src/go.mod
@@ -1,0 +1,11 @@
+module orangepi-5
+
+go 1.23.0
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.8.3
+	golang.org/x/sys v0.27.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/orangepi-5/src/go.sum
+++ b/installers/orangepi-5/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.8.3 h1:raK1oLzSMpwpy/AqkeFyBYkJS+QuOnlRMznVl/rZ25k=
+github.com/siderolabs/talos/pkg/machinery v1.8.3/go.mod h1:cNR2TELu2T9AzYOHAoNr/7ZS3ZVDLzM/KnuOr4XW4s4=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/orangepi-5/src/main.go
+++ b/installers/orangepi-5/src/main.go
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	off int64 = 512 * 64
+	dtb       = "rockchip/rk3588s-orangepi-5.dtb"
+)
+
+func main() {
+	adapter.Execute(&opi5Installer{})
+}
+
+type opi5Installer struct{}
+
+type opi5ExtraOptions struct{}
+
+func (i *opi5Installer) GetOptions(extra opi5ExtraOptions) (overlay.Options, error) {
+	kernelArgs := []string{
+		"console=tty0",
+		"console=ttyS2,115200",
+		"sysctl.kernel.kexec_load_disabled=1",
+		"talos.dashboard.disabled=1",
+	}
+	return overlay.Options{
+		Name:       "opi5",
+		KernelArgs: kernelArgs,
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *opi5Installer) Install(options overlay.InstallOptions[opi5ExtraOptions]) error {
+	var err error
+
+	var (
+		uBootBin = filepath.Join(options.ArtifactsPath, "arm64/u-boot/orangepi-5/u-boot-rockchip.bin")
+	)
+
+	err = uBootLoaderInstall(uBootBin, options.InstallDisk)
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "boot/EFI/dtb", dtb)
+
+	err = copyFileAndCreateDir(src, dst)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func copyFileAndCreateDir(src, dst string) error {
+	err := os.MkdirAll(filepath.Dir(dst), 0o600)
+
+	if err != nil {
+		return err
+	}
+
+	return copy.File(src, dst)
+}
+
+func uBootLoaderInstall(uBootBin, installDisk string) error {
+	var f *os.File
+
+	f, err := os.OpenFile(installDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", installDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(uBootBin)
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to esure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	return err
+}

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -5,6 +5,7 @@ dependencies:
   - stage: helios64
   - stage: nanopi-r5s
   - stage: nanopi-r4s
+  - stage: orangepi-5
   - stage: orangepi-r1-plus-lts
   - stage: rock64
   - stage: rockpi4
@@ -19,6 +20,8 @@ dependencies:
   - stage: u-boot-nanopi-r5s
     platform: linux/arm64
   - stage: u-boot-nanopi-r4s
+    platform: linux/arm64
+  - stage: u-boot-orangepi-5
     platform: linux/arm64
   - stage: u-boot-orangepi-r1-plus-lts
     platform: linux/arm64
@@ -48,6 +51,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-nanopi-r4s.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3399-nanopi-r4s.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3588s-orangepi-5.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3588s-orangepi-5.dtb
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
     platform: linux/arm64
     from: /dtb/rockchip/rk3328-orangepi-r1-plus-lts.dtb

--- a/profiles/orangepi-5/orangepi-5.yaml
+++ b/profiles/orangepi-5/orangepi-5.yaml
@@ -1,0 +1,9 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -7,6 +7,8 @@ finalize:
     to: /rootfs/profiles
   - from: /pkg/nanopi-r4s
     to: /rootfs/profiles
+  - from: /pkg/orangepi-5
+    to: /rootfs/profiles
   - from: /pkg/orangepi-r1-plus-lts
     to: /rootfs/profiles
   - from: /pkg/rock64


### PR DESCRIPTION
This adds support for the orangepi-5.
It reuses rkbin-rk3588.

Tested with orangepi-5. Testing with `ghcr.io/laurinstreng/talos-orangepi-5:v1.9.1`

close #32

Let me know what you think.