### PR TITLE
feat(rk3588): add overlay option to disable uBoot installation for SPI Flash boot

### DIFF
--- a/artifacts/orangepi-5/u-boot/pkg.yaml
+++ b/artifacts/orangepi-5/u-boot/pkg.yaml
@@ -41,7 +41,7 @@ steps:
     install:
       - |
         mkdir -p /rootfs/artifacts/arm64/u-boot/orangepi-5
-        cp -v -t /rootfs/artifacts/arm64/u-boot/orangepi-5 u-boot-rockchip.bin
+        cp -v -t /rootfs/artifacts/arm64/u-boot/orangepi-5 u-boot-rockchip.bin u-boot-rockchip-spi.bin
 finalize:
   - from: /rootfs
     to: /rootfs

--- a/artifacts/rock5b/u-boot/pkg.yaml
+++ b/artifacts/rock5b/u-boot/pkg.yaml
@@ -9,6 +9,7 @@ dependencies:
   - stage: arm-trusted-firmware-rk3588
   - stage: rkbin-rk3588
     platform: linux/amd64
+
 steps:
   - sources:
       - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_rk1_version }}.tar.bz2
@@ -20,16 +21,18 @@ steps:
     prepare:
       # rock-5b-rk3588
       - |
-        mkdir -p /usr/bin \
-          && ln -sf /toolchain/bin/env /usr/bin/env \
-          && ln -sf /toolchain/bin/python3 /toolchain/bin/python
+        mkdir -p /usr/bin
+        ln -sf /toolchain/bin/env /usr/bin/env
+        ln -sf /toolchain/bin/python3 /toolchain/bin/python
 
-        pip3 install pyelftools setuptools \
-          && ln -sf /toolchain/bin/python3 /toolchain/bin/python
+        pip3 install pyelftools setuptools
 
         tar xf u-boot.tar.bz2 --strip-components=1
 
-        patch -p1 < /pkg/patches/uboot-byteorder.patch
+        for patch in $(find /pkg/patches -type f -name "*.patch" | sort); do
+          echo "Applying $patch"
+          patch -p1 < $patch || (echo "Failed to apply patch $patch" && exit 1)
+        done
       - |
         make rock5b-rk3588_defconfig
     build:
@@ -38,7 +41,7 @@ steps:
     install:
       - |
         mkdir -p /rootfs/artifacts/arm64/u-boot/rock5b
-        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/rock5b
+        cp -v -t /rootfs/artifacts/arm64/u-boot/rock5b u-boot-rockchip.bin u-boot-rockchip-spi.bin
 finalize:
   - from: /rootfs
     to: /rootfs


### PR DESCRIPTION
**Add support for disabling uBoot installation on rk3588 boards.**

## Overview

This PR introduces a new overlay option for rk3588 boards (Turing Pi RK1, Orange Pi 5, and ROCK 5B) to disable the installation of uBoot during the setup process.

_Additionally, it renames the Orange Pi 5 board from `opi5` to `orangepi-5` for consistency with the naming conventions of other Orange Pi boards._

## Changes

1. New Overlay Option:
- Provides users with the ability to disable uBoot installation.
- Particularly useful for cases where booting from SPI Flash is preferred (e.g., booting from NVMe or USB drives), as uBoot is not required on the installation disk in such scenarios.

2. Board Renaming:
- Updates the Orange Pi 5 board identifier from `opi5` to `orangepi-5`.
- Aligns naming conventions across all Orange Pi boards for better clarity and consistency.

## Motivation

rk3588 boards include SPI Flash, enabling uBoot to be pre-flashed. For users who wish to boot from alternate devices such as NVMe or USB drives, this flexibility eliminates the need for uBoot installation on the disk.