### PR TITLE
Initial support of ROCKPro64

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,8 +17,9 @@ This document contains a list of maintainers in this repo. For now, you become a
 | rock64               | Pine64 Rock64         | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3328  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | rockpi4              | Rock Pi 4A,Rock Pi 4B | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | rockpi4c             | Rock Pi 4C            | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
+| rockpro64            | Pine64 RockPro64      | [#55](https://github.com/siderolabs/sbc-rockchip/pull/55) | RK3399  | Tim Sandquist                    | [tsndqst](https://github.com/tsndqst)           |
 | rock4cplus           | Radxa ROCK 4C+        | [#5](https://github.com/siderolabs/sbc-rockchip/pull/5)   | RK3399  | Damià Poquet Femenia             | [DamiaPoquet](https://github.com/DamiaPoquet)   |
 | rock4se              | Radxa ROCK 4SE        | [#18](https://github.com/siderolabs/sbc-rockchip/pull/18) | RK3399  | Boran Car                        | [borancar](https://github.com/borancar)         |
-| rock5a               | Radxa ROCK 5A         | [#51](https://github.com/siderolabs/sbc-rockchip/pull/51) | RK3588  | Josh Moore               | [joshdmoore](https://github.com/joshdmoore)             |
+| rock5a               | Radxa ROCK 5A         | [#51](https://github.com/siderolabs/sbc-rockchip/pull/51) | RK3588  | Josh Moore                       | [joshdmoore](https://github.com/joshdmoore)     |
 | rock5b               | Radxa ROCK 5B         | [#45](https://github.com/siderolabs/sbc-rockchip/pull/45) | RK3588  | Christoph Hoopmann               | [choopm](https://github.com/choopm)             |
 | turingrk1            | Turing Machines RK1   | [#35](https://github.com/siderolabs/sbc-rockchip/pull/35) | RK3588  | Nico Berlee                      | [nberlee](https://github.com/nberlee)           |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo provides the overlay for RockChip based Talos image.
 | orangepi-5           | Orange Pi 5           | RK3588s | Overlay for Orange Pi 5                       |
 | orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | RK3328  | Overlay for Orange Pi R1 Plus LTS             |
 | rock64               | Pine64 Rock64         | RK3328  | Overlay for Pine64 Rock64                     |
+| rockpro64            | Pine64 ROCKPro64      | RK3399  | Overlay for Pine64 ROCKPro64                  |
 | rockpi4              | Rock Pi 4A,Rock Pi 4B | RK3399  | Generic overlay for Rock Pi 4A and Rock Pi 4B |
 | rockpi4c             | Rock Pi 4C            | RK3399  | Overlay for Rock Pi 4C                        |
 | rock4se              | Rock 4 SE             | RK3399  | Overlay for Rock 4 SE                         |

--- a/artifacts/rockpro64/u-boot/patches/uboot-byteorder.patch
+++ b/artifacts/rockpro64/u-boot/patches/uboot-byteorder.patch
@@ -1,0 +1,15 @@
+diff --git a/include/linux/byteorder/little_endian.h b/include/linux/byteorder/little_endian.h
+index a4cb3bfde5..0ecd088f4a 100644
+--- a/include/linux/byteorder/little_endian.h
++++ b/include/linux/byteorder/little_endian.h
+@@ -7,7 +7,10 @@
+ #ifndef __LITTLE_ENDIAN_BITFIELD
+ #define __LITTLE_ENDIAN_BITFIELD
+ #endif
++
++#ifndef __BYTE_ORDER
+ #define	__BYTE_ORDER	__LITTLE_ENDIAN
++#endif
+ 
+ #include <linux/compiler.h>
+ #include <linux/types.h>

--- a/artifacts/rockpro64/u-boot/pkg.yaml
+++ b/artifacts/rockpro64/u-boot/pkg.yaml
@@ -1,0 +1,35 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-rockpro64
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: arm-trusted-firmware-rk3399
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_sha256 }}"
+        sha512: "{{ .uboot_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      # rockpro64-rk3399
+      - |
+        tar xf u-boot.tar.bz2 --strip-components=1
+
+        patch -p1 < /pkg/patches/uboot-byteorder.patch
+      - |
+        make rockpro64-rk3399_defconfig
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" BL31=/libs/arm-trusted-firmware/rk3399/bl31.elf
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/rockpro64
+        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/rockpro64
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -5,13 +5,19 @@ project_name = "sbc-rockchip"
 github_repo = "siderolabs/sbc-rockchip"
 match_deps = "^github.com/(siderolabs/[a-zA-Z0-9-]+)$"
 
-previous = "v0.1.2"
+previous = "v0.1.3"
 pre_release = false
 
 [notes]
 
-[notes.orangepi]
-  title = "OrangePi-5"
+[notes.rock5a]
+  title = "Rock 5A"
   description = """
-Add support for OrangePi-5 board.
+Add support for Rock5A board.
+"""
+
+[notes.rockpro64]
+  title = "Pine64 RockPro64"
+  description = """
+Add support for Pine64 RockPro64.
 """

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -8,6 +8,7 @@ dependencies:
   - stage: orangepi-5
   - stage: orangepi-r1-plus-lts
   - stage: rock64
+  - stage: rockpro64
   - stage: rockpi4
   - stage: rockpi4c
   - stage: rock4cplus
@@ -27,6 +28,8 @@ dependencies:
   - stage: u-boot-orangepi-r1-plus-lts
     platform: linux/arm64
   - stage: u-boot-rock64
+    platform: linux/arm64
+  - stage: u-boot-rockpro64
     platform: linux/arm64
   - stage: u-boot-rockpi4
     platform: linux/arm64
@@ -66,6 +69,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3328-rock64.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3328-rock64.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3399-rockpro64-v2.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3399-rockpro64-v2.dtb
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-rock-pi-4b.dtb

--- a/installers/rockpro64/pkg.yaml
+++ b/installers/rockpro64/pkg.yaml
@@ -1,0 +1,33 @@
+name: rockpro64
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /tmp/go
+    network: default
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    prepare:
+      - |
+        cd /pkg/src
+        go mod download
+  - env:
+      GOPATH: /tmp/go
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    build:
+      - |
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./rockpro64 .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp /pkg/src/rockpro64 /rootfs/installers/rockpro64
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/rockpro64/src/go.mod
+++ b/installers/rockpro64/src/go.mod
@@ -1,0 +1,11 @@
+module rockpro64
+
+go 1.24.0
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.9.4
+	golang.org/x/sys v0.31.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/rockpro64/src/go.sum
+++ b/installers/rockpro64/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.9.4 h1:ReKkU5gaf5h/cZde3ME45hREgOEWODTJYfBFeMhZGkA=
+github.com/siderolabs/talos/pkg/machinery v1.9.4/go.mod h1:yLkJ5ZvIpshDRhUVWjuSyTN6YAQiusSJF4/zj2/XfpY=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/rockpro64/src/main.go
+++ b/installers/rockpro64/src/main.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	off   int64 = 512 * 64
+	board       = "rockpro64"
+	dtb         = "rockchip/rk3399-rockpro64-v2.dtb"
+)
+
+func main() {
+	adapter.Execute(&rockPro64{})
+}
+
+type rockPro64 struct{}
+
+type rockPro64ExtraOptions struct{}
+
+func (i *rockPro64) GetOptions(extra rockPro64ExtraOptions) (overlay.Options, error) {
+	return overlay.Options{
+		Name: board,
+		KernelArgs: []string{
+			"console=tty0",
+			"console=ttyS2,1500000n8",
+			"sysctl.kernel.kexec_load_disabled=1",
+			"talos.dashboard.disabled=1",
+		},
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *rockPro64) Install(options overlay.InstallOptions[rockPro64ExtraOptions]) error {
+	var f *os.File
+
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", options.InstallDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to esure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	return copy.File(src, dst)
+}

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -13,6 +13,8 @@ finalize:
     to: /rootfs/profiles
   - from: /pkg/rock64
     to: /rootfs/profiles
+  - from: /pkg/rockpro64
+    to: /rootfs/profiles
   - from: /pkg/rockpi4
     to: /rootfs/profiles
   - from: /pkg/rockpi4c

--- a/profiles/rockpro64/rockpro64.yaml
+++ b/profiles/rockpro64/rockpro64.yaml
@@ -1,0 +1,9 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw


### PR DESCRIPTION
I haven't used Talos very long but I have some ROCKPro64s around so I thought I'd try making an overlay.  I believe this works.  It seems to work the same as the generic metal ISO.

Closes https://github.com/siderolabs/sbc-rockchip/issues/44