### PR TITLE
chore: update the kernel for correct tsadc thermal shutdown in RK1

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ This document contains a list of maintainers in this repo. For now, you become a
 
 | Overlay Name         | Board                 | PR                                                        | SoC     | Maintainer                       | GitHub ID                                       |
 | -------------------- | --------------------- | --------------------------------------------------------- | ------- | -------------------------------- | ----------------------------------------------- |
+| helios64             | Kobol Helios64        | [#23](https://github.com/siderolabs/sbc-rockchip/pull/23) | RK3399  | Hemanth Bollamreddi              | [blmhemu](https://github.com/blmhemu)           |
 | nanopi-r4s           | NanoPi R4S            | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | nanopi-r5s           | NanoPi R5S            | [#16](https://github.com/siderolabs/sbc-rockchip/pull/16) | RK3568  | Nicklas Frahm                    | [nicklasfrahm](https://github.com/nicklasfrahm) |
 | orangepi-5           | Orange Pi 5           | [#47](https://github.com/siderolabs/sbc-rockchip/pull/47) | RK3588s | Laurin Streng                    | [laurinstreng](https://github.com/LaurinStreng) |
@@ -20,4 +21,4 @@ This document contains a list of maintainers in this repo. For now, you become a
 | rock4se              | Radxa ROCK 4SE        | [#18](https://github.com/siderolabs/sbc-rockchip/pull/18) | RK3399  | Boran Car                        | [borancar](https://github.com/borancar)         |
 | rock5a               | Radxa ROCK 5A         | [#51](https://github.com/siderolabs/sbc-rockchip/pull/51) | RK3588  | Josh Moore               | [joshdmoore](https://github.com/joshdmoore)             |
 | rock5b               | Radxa ROCK 5B         | [#45](https://github.com/siderolabs/sbc-rockchip/pull/45) | RK3588  | Christoph Hoopmann               | [choopm](https://github.com/choopm)             |
-| helios64             | Kobol Helios64        | [#23](https://github.com/siderolabs/sbc-rockchip/pull/23) | RK3399  | Hemanth Bollamreddi              | [blmhemu](https://github.com/blmhemu)           |
+| turingrk1            | Turing Machines RK1   | [#35](https://github.com/siderolabs/sbc-rockchip/pull/35) | RK3588  | Nico Berlee                      | [nberlee](https://github.com/nberlee)           |

--- a/Pkgfile
+++ b/Pkgfile
@@ -18,7 +18,7 @@ vars:
   uboot_sha512: 678f44e2b9132140f0bf05c637e57e638c73c278611037a41824b3ebff2131af4dec0163da4664bb2e5c4fd8034ba8c95b93b57f7aa9f4c045da322d87c3b5e9
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=u-boot/u-boot
-  uboot_rk1_version: 2025.01
+  uboot_rk1_version: 2024.10
   uboot_rk1_sha256: b28daf4ac17e43156363078bf510297584137f6df50fced9b12df34f61a92fb0
   uboot_rk1_sha512: ef817c9b5ae8dc6cd9e3f57811e90acc6a4d4394f0356aa5923e3e3c8559168f977bd5bf82824cd3650aa8e5e3c3d1b00e20818d21368151748682f1fc51152c
 
@@ -28,9 +28,9 @@ vars:
   rkbin_sha512: f414b26f944e2119d6be93c1675d1bbbd2770141e229a3ffe0a176e6dc25d9cea506e7456344d714ac563af64ad708fe93cca9e184353a1b60d8881285d81822
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-  linux_version: 6.12.1
-  linux_sha256: 0193b1d86dd372ec891bae799f6da20deef16fc199f30080a4ea9de8cef0c619
-  linux_sha512: c7523dc5b012367301ab43a685b766dce025c4993041acd3dacd085b052b3fccc7f50c892357acf481e24ccad512770ef46a13d2da16c2a178c44a27f7022932
+  linux_version: 6.12.17
+  linux_sha256: 5c205cd34f80974e4973e321cb008f5f6895a8aa8c2577f06a9448cd77de63b3
+  linux_sha512: 16f1c0b5f54a9e9af4b41eaf43a3189ede80a03b4caf6430b563b7f1a09258b831e64517e788b57a49755b8e3e3828bd9d92892a3b858fa1c0359ad50585449a
 
   # renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
   wolfi_base_ref: sha256:8dd9ceace8b1574e550374e9c07c2baafa60cc96223c1314fac61bd2edb48c70


### PR DESCRIPTION
In kernel 6.12.17 it reads in the changelog:
    The tsadc driver does not handle pinctrl "gpio" and "otpout".
    Let's use the correct pinctrl names "default" and "sleep".
    Additionally, Alexey Charkov's testing [1] has established that
    it is necessary for pinctrl state to reference the &tsadc_shut_org
    configuration rather than &tsadc_shut for the driver to function correctly.

This means thermal shutdown effectively starts functioning if overheated.

Oh and add me to the maintainers for the RK1