### PR TITLE
feat(odroid-m1): Add initial board support

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ This document contains a list of maintainers in this repo. For now, you become a
 | helios64             | Kobol Helios64        | [#23](https://github.com/siderolabs/sbc-rockchip/pull/23) | RK3399  | Hemanth Bollamreddi              | [blmhemu](https://github.com/blmhemu)           |
 | nanopi-r4s           | NanoPi R4S            | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | nanopi-r5s           | NanoPi R5S            | [#16](https://github.com/siderolabs/sbc-rockchip/pull/16) | RK3568  | Nicklas Frahm                    | [nicklasfrahm](https://github.com/nicklasfrahm) |
+| odroid-m1            | Hardkernel Odroid M1  | [#67](https://github.com/siderolabs/sbc-rockchip/pull/67) | RK3568  | Albert Lloveras Carbonell        | [alloveras](https://github.com/alloveras)       |
 | orangepi-5           | Orange Pi 5           | [#47](https://github.com/siderolabs/sbc-rockchip/pull/47) | RK3588s | Laurin Streng                    | [laurinstreng](https://github.com/LaurinStreng) |
 | orangepi-5-plus      | Orange Pi 5 Plus      | [#52](https://github.com/siderolabs/sbc-rockchip/pull/52) | RK3588  | Ryan Persée                      | [rpersee](https://github.com/rpersee)           |
 | orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | [#9](https://github.com/siderolabs/sbc-rockchip/pull/9)   | RK3328  | Giau. Tran Minh                  | [giautm](https://github.com/giautm)             |

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This repo provides the overlay for RockChip based Talos image.
 | Overlay Name         | Board                 | SoC     | Description                                   |
 | -------------------- | --------------------- | ------- | --------------------------------------------- |
 | helios64             | Kobol Helios64        | RK3399  | Overlay for Kobol Helios64                    |
-| nanopi-r5s           | NanoPi R5S            | RK3568  | Overlay for NanoPi R5S (only WAN, no NVMe)    |
 | nanopi-r4s           | NanoPi R4S            | RK3399  | Overlay for NanoPi R4S                        |
+| nanopi-r5s           | NanoPi R5S            | RK3568  | Overlay for NanoPi R5S (only WAN, no NVMe)    |
+| odroid-m1            | Hardkernel Odroid M1  | RK3568  | Overlay for Hardkernel's Odroid M1            |
 | orangepi-5           | Orange Pi 5           | RK3588s | Overlay for Orange Pi 5                       |
 | orangepi-5-plus      | Orange Pi 5 Plus      | RK3588  | Overlay for Orange Pi 5 Plus                  |
 | orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | RK3328  | Overlay for Orange Pi R1 Plus LTS             |

--- a/artifacts/odroid-m1/u-boot/patches/uboot-byteorder.patch
+++ b/artifacts/odroid-m1/u-boot/patches/uboot-byteorder.patch
@@ -1,0 +1,15 @@
+diff --git a/include/linux/byteorder/little_endian.h b/include/linux/byteorder/little_endian.h
+index a4cb3bfde5..0ecd088f4a 100644
+--- a/include/linux/byteorder/little_endian.h
++++ b/include/linux/byteorder/little_endian.h
+@@ -7,7 +7,10 @@
+ #ifndef __LITTLE_ENDIAN_BITFIELD
+ #define __LITTLE_ENDIAN_BITFIELD
+ #endif
++
++#ifndef __BYTE_ORDER
+ #define	__BYTE_ORDER	__LITTLE_ENDIAN
++#endif
+
+ #include <linux/compiler.h>
+ #include <linux/types.h>

--- a/artifacts/odroid-m1/u-boot/pkg.yaml
+++ b/artifacts/odroid-m1/u-boot/pkg.yaml
@@ -1,0 +1,36 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-odroid-m1
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: arm-trusted-firmware-rk3568
+  - stage: rkbin-rk3568
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_sha256 }}"
+        sha512: "{{ .uboot_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      # odroid-m1
+      - |
+        tar xf u-boot.tar.bz2 --strip-components=1
+
+        patch -p1 < /pkg/patches/uboot-byteorder.patch
+      - |
+        make odroid-m1-rk3568_defconfig
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" BL31=/libs/arm-trusted-firmware/rk3568/bl31.elf ROCKCHIP_TPL=/libs/rkbin/rk3568_ddr_1560MHz_v1.23.bin
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/odroid-m1
+        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/odroid-m1
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	./installers/helios64/src
 	./installers/nanopi-r5s/src
 	./installers/nanopi-r4s/src
+	./installers/odroid-m1/src
 	./installers/orangepi-5/src
 	./installers/orangepi-5-plus/src
 	./installers/orangepi-r1-plus-lts/src

--- a/installers/odroid-m1/pkg.yaml
+++ b/installers/odroid-m1/pkg.yaml
@@ -1,0 +1,33 @@
+name: odroid-m1
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /tmp/go
+    network: default
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    prepare:
+      - |
+        cd /pkg/src
+        go mod download
+  - env:
+      GOPATH: /tmp/go
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    build:
+      - |
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./odroid-m1 .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp /pkg/src/odroid-m1 /rootfs/installers/odroid-m1
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/odroid-m1/src/go.mod
+++ b/installers/odroid-m1/src/go.mod
@@ -1,0 +1,11 @@
+module odroid-m1
+
+go 1.24.0
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.9.5
+	golang.org/x/sys v0.32.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/odroid-m1/src/go.sum
+++ b/installers/odroid-m1/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.9.5 h1:hH+f48MLNoDUeyny1zR/i2fLqReK64Fq9WmIizL8GEs=
+github.com/siderolabs/talos/pkg/machinery v1.9.5/go.mod h1:yLkJ5ZvIpshDRhUVWjuSyTN6YAQiusSJF4/zj2/XfpY=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/odroid-m1/src/main.go
+++ b/installers/odroid-m1/src/main.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	off   int64 = 512 * 64
+	board       = "odroid-m1"
+	dtb         = "rockchip/rk3568-odroid-m1.dtb"
+)
+
+func main() {
+	adapter.Execute(&odroidm1{})
+}
+
+type odroidm1 struct{}
+
+type odroidm1ExtraOptions struct{}
+
+func (i *odroidm1) GetOptions(extra odroidm1ExtraOptions) (overlay.Options, error) {
+	return overlay.Options{
+		Name: "odroid-m1",
+		KernelArgs: []string{
+			"console=tty0",
+			"console=ttyS2,1500000n8",
+			"sysctl.kernel.kexec_load_disabled=1",
+			"talos.dashboard.disabled=1",
+		},
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *odroidm1) Install(options overlay.InstallOptions[odroidm1ExtraOptions]) error {
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", options.InstallDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot", board, "u-boot-rockchip.bin"))
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to ensure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	if err := copy.File(src, dst); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -5,6 +5,7 @@ dependencies:
   - stage: helios64
   - stage: nanopi-r5s
   - stage: nanopi-r4s
+  - stage: odroid-m1
   - stage: orangepi-5
   - stage: orangepi-5-plus
   - stage: orangepi-r1-plus-lts
@@ -23,6 +24,8 @@ dependencies:
   - stage: u-boot-nanopi-r5s
     platform: linux/arm64
   - stage: u-boot-nanopi-r4s
+    platform: linux/arm64
+  - stage: u-boot-odroid-m1
     platform: linux/arm64
   - stage: u-boot-orangepi-5
     platform: linux/arm64
@@ -52,6 +55,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-kobol-helios64.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3399-kobol-helios64.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3568-odroid-m1.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3568-odroid-m1.dtb
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
     platform: linux/arm64
     from: /dtb/rockchip/rk3568-nanopi-r5s.dtb

--- a/profiles/odroid-m1/odroid-m1.yaml
+++ b/profiles/odroid-m1/odroid-m1.yaml
@@ -1,0 +1,10 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: grub

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -7,6 +7,8 @@ finalize:
     to: /rootfs/profiles
   - from: /pkg/nanopi-r4s
     to: /rootfs/profiles
+  - from: /pkg/odroid-m1
+    to: /rootfs/profiles
   - from: /pkg/orangepi-5
     to: /rootfs/profiles
   - from: /pkg/orangepi-5-plus


### PR DESCRIPTION
## Intent
To add support for HardKernel's ODROID-M1.

So far, with this overlay, the board can boot from an SD card and recognize the most important peripherals (e.g., network card, NVMe, etc).

I think that, for the board to boot successfully from the NVME, it is necessary to flash the SPI with u-boot since I don't believe [petitboot](https://github.com/open-power/petitboot) supports that. 

In my case, I had already flashed my board's SPI with `u-boot` since I was running Armbian previously, and it was required to boot from NVMe. So, I didn't try whether petiboot works or not, but I thought it was worth mentioning here in case folks have trouble booting from NVMe without flashing `u-boot` into the SPI.