### PR TITLE
Add Radxa ZERO 3E support

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,6 +16,7 @@ This document contains a list of maintainers in this repo. For now, you become a
 | orangepi-5           | Orange Pi 5           | [#47](https://github.com/siderolabs/sbc-rockchip/pull/47) | RK3588s | Laurin Streng                    | [laurinstreng](https://github.com/LaurinStreng) |
 | orangepi-5-plus      | Orange Pi 5 Plus      | [#52](https://github.com/siderolabs/sbc-rockchip/pull/52) | RK3588  | Ryan Persée                      | [rpersee](https://github.com/rpersee)           |
 | orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | [#9](https://github.com/siderolabs/sbc-rockchip/pull/9)   | RK3328  | Giau. Tran Minh                  | [giautm](https://github.com/giautm)             |
+| radxa-zero-3e        | Radxa ZERO 3E         | [#71](https://github.com/siderolabs/sbc-rockchip/pull/71) | RK3566  | Noah Craig                       | [tyraeis](https://github.com/tyraeis)           |
 | rock64               | Pine64 Rock64         | [#4](https://github.com/siderolabs/sbc-rockchip/pull/4)   | RK3328  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | rockpi4              | Rock Pi 4A,Rock Pi 4B | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | rockpi4c             | Rock Pi 4C            | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repo provides the overlay for RockChip based Talos image.
 | orangepi-5           | Orange Pi 5           | RK3588s | Overlay for Orange Pi 5                       |
 | orangepi-5-plus      | Orange Pi 5 Plus      | RK3588  | Overlay for Orange Pi 5 Plus                  |
 | orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | RK3328  | Overlay for Orange Pi R1 Plus LTS             |
+| radxa-zero-3e        | Radxa ZERO 3E         | RK3566  | Overlay for Radxa ZERO 3E                     |
 | rock64               | Pine64 Rock64         | RK3328  | Overlay for Pine64 Rock64                     |
 | rockpro64            | Pine64 ROCKPro64      | RK3399  | Overlay for Pine64 ROCKPro64                  |
 | rockpi4              | Rock Pi 4A,Rock Pi 4B | RK3399  | Generic overlay for Rock Pi 4A and Rock Pi 4B |

--- a/artifacts/radxa-zero-3/u-boot/patches/uboot-byteorder.patch
+++ b/artifacts/radxa-zero-3/u-boot/patches/uboot-byteorder.patch
@@ -1,0 +1,15 @@
+diff --git a/include/linux/byteorder/little_endian.h b/include/linux/byteorder/little_endian.h
+index a4cb3bfde5..0ecd088f4a 100644
+--- a/include/linux/byteorder/little_endian.h
++++ b/include/linux/byteorder/little_endian.h
+@@ -7,7 +7,10 @@
+ #ifndef __LITTLE_ENDIAN_BITFIELD
+ #define __LITTLE_ENDIAN_BITFIELD
+ #endif
++
++#ifndef __BYTE_ORDER
+ #define	__BYTE_ORDER	__LITTLE_ENDIAN
++#endif
+ 
+ #include <linux/compiler.h>
+ #include <linux/types.h>

--- a/artifacts/radxa-zero-3/u-boot/pkg.yaml
+++ b/artifacts/radxa-zero-3/u-boot/pkg.yaml
@@ -1,0 +1,39 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-radxa-zero-3
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  # arm-trusted-firmware treats rk3566/rk3568 as a single platform
+  - stage: arm-trusted-firmware-rk3568
+  - stage: rkbin-rk3566
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_rk1_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_rk1_sha256 }}"
+        sha512: "{{ .uboot_rk1_sha512 }}"
+    env:
+        SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      # radxa-zero-3-rk3566
+      - |
+        tar xf u-boot.tar.bz2 --strip-components=1
+
+        patch -p1 < /pkg/patches/uboot-byteorder.patch
+      - |
+        make radxa-zero-3-rk3566_defconfig
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" \
+          BL31=/libs/arm-trusted-firmware/rk3568/bl31.elf \
+          ROCKCHIP_TPL=/libs/rkbin/rk3566_ddr_1056MHz_v1.23.bin
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/radxa-zero-3
+        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/radxa-zero-3
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/artifacts/rkbin/rk3566/pkg.yaml
+++ b/artifacts/rkbin/rk3566/pkg.yaml
@@ -1,0 +1,25 @@
+name: rkbin-rk3566
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://github.com/rockchip-linux/rkbin/archive/{{ .rkbin_ref }}.tar.gz
+        destination: rkbin.tar.gz
+        sha256: "{{ .rkbin_sha256 }}"
+        sha512: "{{ .rkbin_sha512 }}"
+    env:
+      SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      - |
+        tar xf rkbin.tar.gz --strip-components=1
+    build:
+    install:
+      - |
+        mkdir -p /rootfs/rkbin
+
+        cp bin/rk35/rk3566_ddr_1056MHz_* /rootfs/rkbin/
+finalize:
+  - from: /rootfs
+    to: /libs

--- a/go.work
+++ b/go.work
@@ -8,6 +8,7 @@ use (
 	./installers/orangepi-5/src
 	./installers/orangepi-5-plus/src
 	./installers/orangepi-r1-plus-lts/src
+	./installers/radxa-zero-3e/src
 	./installers/rock64/src
 	./installers/rockpi4/src
 	./installers/rockpi4c/src

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -9,6 +9,7 @@ dependencies:
   - stage: orangepi-5
   - stage: orangepi-5-plus
   - stage: orangepi-r1-plus-lts
+  - stage: radxa-zero-3e
   - stage: rock64
   - stage: rockpro64
   - stage: rockpi4
@@ -32,6 +33,8 @@ dependencies:
   - stage: u-boot-orangepi-5-plus
     platform: linux/arm64
   - stage: u-boot-orangepi-r1-plus-lts
+    platform: linux/arm64
+  - stage: u-boot-radxa-zero-3
     platform: linux/arm64
   - stage: u-boot-rock64
     platform: linux/arm64
@@ -79,6 +82,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3328-orangepi-r1-plus-lts.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3328-orangepi-r1-plus-lts.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3566-radxa-zero-3e.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3566-radxa-zero-3e.dtb
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
     platform: linux/arm64
     from: /dtb/rockchip/rk3328-rock64.dtb

--- a/installers/radxa-zero-3e/pkg.yaml
+++ b/installers/radxa-zero-3e/pkg.yaml
@@ -1,0 +1,33 @@
+name: radxa-zero-3e
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /tmp/go
+    network: default
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    prepare:
+      - |
+        cd /pkg/src
+        go mod download
+  - env:
+      GOPATH: /tmp/go
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    build:
+      - |
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./radxa-zero-3e .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp /pkg/src/radxa-zero-3e /rootfs/installers/radxa-zero-3e
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/radxa-zero-3e/src/go.mod
+++ b/installers/radxa-zero-3e/src/go.mod
@@ -1,0 +1,11 @@
+module radxa-zero-3e
+
+go 1.24.0
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.9.5
+	golang.org/x/sys v0.32.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/radxa-zero-3e/src/go.sum
+++ b/installers/radxa-zero-3e/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.9.5 h1:hH+f48MLNoDUeyny1zR/i2fLqReK64Fq9WmIizL8GEs=
+github.com/siderolabs/talos/pkg/machinery v1.9.5/go.mod h1:yLkJ5ZvIpshDRhUVWjuSyTN6YAQiusSJF4/zj2/XfpY=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/radxa-zero-3e/src/main.go
+++ b/installers/radxa-zero-3e/src/main.go
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	off int64 = 512 * 64
+	dtb       = "rockchip/rk3566-radxa-zero-3e.dtb"
+)
+
+func main() {
+	adapter.Execute(&radxaZero3e{})
+}
+
+type radxaZero3e struct{}
+
+type radxaZero3eExtraOptions struct{}
+
+func (i *radxaZero3e) GetOptions(extra radxaZero3eExtraOptions) (overlay.Options, error) {
+	return overlay.Options{
+		Name: "radxa-zero-3e",
+		KernelArgs: []string{
+			"console=tty0",
+			"console=ttyS2,1500000n8",
+			"sysctl.kernel.kexec_load_disabled=1",
+			"talos.dashboard.disabled=1",
+		},
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *radxaZero3e) Install(options overlay.InstallOptions[radxaZero3eExtraOptions]) error {
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", options.InstallDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/radxa-zero-3/u-boot-rockchip.bin"))
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to ensure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	return copy.File(src, dst)
+}

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -15,6 +15,8 @@ finalize:
     to: /rootfs/profiles
   - from: /pkg/orangepi-r1-plus-lts
     to: /rootfs/profiles
+  - from: /pkg/radxa-zero-3e
+    to: /rootfs/profiles
   - from: /pkg/rock64
     to: /rootfs/profiles
   - from: /pkg/rockpro64

--- a/profiles/radxa-zero-3e/radxa-zero-3e.yaml
+++ b/profiles/radxa-zero-3e/radxa-zero-3e.yaml
@@ -1,0 +1,10 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: grub


### PR DESCRIPTION
Adds support for Radxa ZERO 3E, mostly based on the odroid-m1 code.

From what I could tell, arm-trusted-firmware treats the rk3566 and rk3568 as the same platform, which is why the u-boot pkg.yaml refers to arm-trusted-firmware-rk3568.

Also, u-boot treats the 3E and 3W as the same platform but they have different DTBs, so the u-boot package is named "u-boot-radxa-zero-3" (no 'e') while the overlay itself is named "radxa-zero-3e" (with 'e'). If someone wanted to add 3W support they should be able to use the same "u-boot-radxa-zero-3" package (though it would be a bit odd to use wifi for a k8s cluster).

This is my first time working at this low a level on an SoC,  but I was able to add three of these to my k8s homelab as dedicated control plane nodes and they seem to be working fine.