### PR TITLE
feat: add Radxa Rock3b support

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,6 +21,7 @@ This document contains a list of maintainers in this repo. For now, you become a
 | rockpi4              | Rock Pi 4A,Rock Pi 4B | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | rockpi4c             | Rock Pi 4C            | [#1](https://github.com/siderolabs/sbc-rockchip/pull/1)   | RK3399  | TBD (Initial PR moved from pkgs) | TBD                                             |
 | rockpro64            | Pine64 RockPro64      | [#55](https://github.com/siderolabs/sbc-rockchip/pull/55) | RK3399  | Tim Sandquist                    | [tsndqst](https://github.com/tsndqst)           |
+| rock3b               | Radxa ROCK 3B         | [#73](https://github.com/siderolabs/sbc-rockchip/pull/73) | RK3568  | Micha Bauer                      | [mi-bauer](https://github.com/mi-bauer)         |
 | rock4cplus           | Radxa ROCK 4C+        | [#5](https://github.com/siderolabs/sbc-rockchip/pull/5)   | RK3399  | Damià Poquet Femenia             | [DamiaPoquet](https://github.com/DamiaPoquet)   |
 | rock4se              | Radxa ROCK 4SE        | [#18](https://github.com/siderolabs/sbc-rockchip/pull/18) | RK3399  | Boran Car                        | [borancar](https://github.com/borancar)         |
 | rock5a               | Radxa ROCK 5A         | [#51](https://github.com/siderolabs/sbc-rockchip/pull/51) | RK3588  | Josh Moore                       | [joshdmoore](https://github.com/joshdmoore)     |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repo provides the overlay for RockChip based Talos image.
 | orangepi-5-plus      | Orange Pi 5 Plus      | RK3588  | Overlay for Orange Pi 5 Plus                  |
 | orangepi-r1-plus-lts | Orange Pi R1 Plus LTS | RK3328  | Overlay for Orange Pi R1 Plus LTS             |
 | radxa-zero-3e        | Radxa ZERO 3E         | RK3566  | Overlay for Radxa ZERO 3E                     |
+| rock3b               | Radxa ROCK 3B         | RK3568  | Overlay for Radxa ROCK 3B                     |
 | rock4cplus           | Radxa ROCK 4C+        | RK3399  | Overlay for Radxa ROCK 4C+                    |
 | rock4se              | Rock 4 SE             | RK3399  | Overlay for Rock 4 SE                         |
 | rock5a               | Radxa ROCK 5A         | RK3588s | Overlay for Radxa ROCK 5A                     |

--- a/artifacts/rock3b/u-boot/patches/uboot-byteorder.patch
+++ b/artifacts/rock3b/u-boot/patches/uboot-byteorder.patch
@@ -1,0 +1,15 @@
+diff --git a/include/linux/byteorder/little_endian.h b/include/linux/byteorder/little_endian.h
+index a4cb3bfde5..0ecd088f4a 100644
+--- a/include/linux/byteorder/little_endian.h
++++ b/include/linux/byteorder/little_endian.h
+@@ -7,7 +7,10 @@
+ #ifndef __LITTLE_ENDIAN_BITFIELD
+ #define __LITTLE_ENDIAN_BITFIELD
+ #endif
++
++#ifndef __BYTE_ORDER
+ #define	__BYTE_ORDER	__LITTLE_ENDIAN
++#endif
+ 
+ #include <linux/compiler.h>
+ #include <linux/types.h>

--- a/artifacts/rock3b/u-boot/pkg.yaml
+++ b/artifacts/rock3b/u-boot/pkg.yaml
@@ -1,0 +1,37 @@
+# References:
+#   U-Boot:
+#     - https://u-boot.readthedocs.io/en/latest
+name: u-boot-rock3b
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: arm-trusted-firmware-rk3568
+  - stage: rkbin-rk3568
+steps:
+  - sources:
+      - url: https://ftp.denx.de/pub/u-boot/u-boot-{{ .uboot_rk1_version }}.tar.bz2
+        destination: u-boot.tar.bz2
+        sha256: "{{ .uboot_rk1_sha256 }}"
+        sha512: "{{ .uboot_rk1_sha512 }}"
+    env:
+        SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
+    prepare:
+      - |
+        tar xf u-boot.tar.bz2 --strip-components=1
+
+        patch -p1 < /pkg/patches/uboot-byteorder.patch
+      - |
+        make rock-3b-rk3568_defconfig
+    build:
+      - |
+        make -j $(nproc) HOSTLDLIBS_mkimage="-lssl -lcrypto" \
+          BL31=/libs/arm-trusted-firmware/rk3568/bl31.elf \
+          ROCKCHIP_TPL=/libs/rkbin/rk3568_ddr_1560MHz_v1.23.bin
+    install:
+      - |
+        mkdir -p /rootfs/artifacts/arm64/u-boot/rock3b
+        cp u-boot-rockchip.bin /rootfs/artifacts/arm64/u-boot/rock3b
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/go.work
+++ b/go.work
@@ -12,6 +12,7 @@ use (
 	./installers/rock64/src
 	./installers/rockpi4/src
 	./installers/rockpi4c/src
+	./installers/rock3b/src
 	./installers/rock4cplus/src
 	./installers/rock4se/src
 	./installers/rock5a/src

--- a/installers/pkg.yaml
+++ b/installers/pkg.yaml
@@ -14,6 +14,7 @@ dependencies:
   - stage: rockpro64
   - stage: rockpi4
   - stage: rockpi4c
+  - stage: rock3b
   - stage: rock4cplus
   - stage: rock4se
   - stage: rock5a
@@ -43,6 +44,8 @@ dependencies:
   - stage: u-boot-rockpi4
     platform: linux/arm64
   - stage: u-boot-rockpi4c
+    platform: linux/arm64
+  - stage: u-boot-rock3b
     platform: linux/arm64
   - stage: u-boot-rock4cplus
     platform: linux/arm64
@@ -106,6 +109,10 @@ dependencies:
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-rock-4c-plus.dtb
     to: /rootfs/artifacts/arm64/dtb/rockchip/rk3399-rock-4c-plus.dtb
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+    platform: linux/arm64
+    from: /dtb/rockchip/rk3568-rock-3b.dtb
+    to: /rootfs/artifacts/arm64/dtb/rockchip/rk3568-rock-3b.dtb
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
     platform: linux/arm64
     from: /dtb/rockchip/rk3399-rock-4se.dtb

--- a/installers/rock3b/pkg.yaml
+++ b/installers/rock3b/pkg.yaml
@@ -1,0 +1,33 @@
+name: rock3b
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+steps:
+  - env:
+      GOPATH: /tmp/go
+    network: default
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    prepare:
+      - |
+        cd /pkg/src
+        go mod download
+  - env:
+      GOPATH: /tmp/go
+    cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    build:
+      - |
+        cd /pkg/src
+        CGO_ENABLED=0 go build -o ./rock3b .
+    install:
+      - |
+        mkdir -p /rootfs/installers/
+
+        cp /pkg/src/rock3b /rootfs/installers/rock3b
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/installers/rock3b/src/go.mod
+++ b/installers/rock3b/src/go.mod
@@ -1,0 +1,11 @@
+module rock3b
+
+go 1.24.0
+
+require (
+	github.com/siderolabs/go-copy v0.1.0
+	github.com/siderolabs/talos/pkg/machinery v1.9.5
+	golang.org/x/sys v0.32.0
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/installers/rock3b/src/go.sum
+++ b/installers/rock3b/src/go.sum
@@ -1,0 +1,10 @@
+github.com/siderolabs/go-copy v0.1.0 h1:OIWCtSg+rhOtnIZTpT31Gfpn17rv5kwJqQHG+QUEgC8=
+github.com/siderolabs/go-copy v0.1.0/go.mod h1:4bF2rZOZAR/ags/U4AVSpjFE5RPGdEeSkOq6yR9YOkU=
+github.com/siderolabs/talos/pkg/machinery v1.9.5 h1:hH+f48MLNoDUeyny1zR/i2fLqReK64Fq9WmIizL8GEs=
+github.com/siderolabs/talos/pkg/machinery v1.9.5/go.mod h1:yLkJ5ZvIpshDRhUVWjuSyTN6YAQiusSJF4/zj2/XfpY=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/installers/rock3b/src/main.go
+++ b/installers/rock3b/src/main.go
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-copy/copy"
+	"github.com/siderolabs/talos/pkg/machinery/overlay"
+	"github.com/siderolabs/talos/pkg/machinery/overlay/adapter"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	off int64 = 512 * 64
+	dtb       = "rockchip/rk3568-rock-3b.dtb"
+)
+
+func main() {
+	adapter.Execute(&rock3b{})
+}
+
+type rock3b struct{}
+
+type rock3bExtraOptions struct{}
+
+func (i *rock3b) GetOptions(extra rock3bExtraOptions) (overlay.Options, error) {
+	return overlay.Options{
+		Name: "rock3b",
+		KernelArgs: []string{
+			"console=tty0",
+			"console=ttyS2,1500000n8",
+			"sysctl.kernel.kexec_load_disabled=1",
+			"talos.dashboard.disabled=1",
+		},
+		PartitionOptions: overlay.PartitionOptions{
+			Offset: 2048 * 10,
+		},
+	}, nil
+}
+
+func (i *rock3b) Install(options overlay.InstallOptions[rock3bExtraOptions]) error {
+	var f *os.File
+
+	f, err := os.OpenFile(options.InstallDisk, os.O_RDWR|unix.O_CLOEXEC, 0o666)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", options.InstallDisk, err)
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rock3b/u-boot-rockchip.bin"))
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(uboot, off); err != nil {
+		return err
+	}
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to ensure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
+	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	return copy.File(src, dst)
+}

--- a/profiles/pkg.yaml
+++ b/profiles/pkg.yaml
@@ -25,6 +25,8 @@ finalize:
     to: /rootfs/profiles
   - from: /pkg/rockpi4c
     to: /rootfs/profiles
+  - from: /pkg/rock3b
+    to: /rootfs/profiles
   - from: /pkg/rock4cplus
     to: /rootfs/profiles
   - from: /pkg/rock4se

--- a/profiles/rock3b/rock3b.yaml
+++ b/profiles/rock3b/rock3b.yaml
@@ -1,0 +1,10 @@
+arch: arm64
+platform: metal
+secureboot: false
+output:
+  kind: image
+  outFormat: .xz
+  imageOptions:
+    diskSize: 1306525696
+    diskFormat: raw
+    bootloader: grub


### PR DESCRIPTION
Add Radxa Rock3b support.

The resulting overlay was tested on a Radxa Rock3b booting from an SD card.